### PR TITLE
Corrected filename in compile command

### DIFF
--- a/examples/cpp.md
+++ b/examples/cpp.md
@@ -21,7 +21,7 @@
 1. Run the following commands:
 
     ```bash
-    g++ -o hellopp hello.cpp
+    g++ -o hellocpp hello.cpp
     ./hellocpp
     ```
 


### PR DESCRIPTION
The compile command is missing a 'c' in 'hellocpp' filename.